### PR TITLE
Refactored setup and added error handling for get_file_size

### DIFF
--- a/bin/common.c
+++ b/bin/common.c
@@ -3,23 +3,26 @@
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 
-off_t get_file_size(int fd) {
+static int get_file_size(int fd, off_t *size) {
     struct stat st;
 
     if(fstat(fd, &st) < 0) {
         perror("fstat");
         return -1;
     }
-
     if (S_ISBLK(st.st_mode)) {
         unsigned long long bytes;
+
         if (ioctl(fd, BLKGETSIZE64, &bytes) != 0) {
             perror("ioctl");
             return -1;
         }
-        return bytes;
-    } else if (S_ISREG(st.st_mode))
-        return st.st_size;
+        *size = bytes;
+        return 0;
+    } else if (S_ISREG(st.st_mode)) {
+        *size = st.st_size;
+        return 0;
+    }
 
     return -1;
 }


### PR DESCRIPTION
As the title suggests, just thought that it would be good differentiate the error code from the size variable.

Added static for visibility restriction - just for coding practice